### PR TITLE
Certify API to use the correct 0-padded 256-bit digest

### DIFF
--- a/bbc2/lib/document_lib.py
+++ b/bbc2/lib/document_lib.py
@@ -28,6 +28,7 @@ import xml.etree.ElementTree as ET
 
 from bbc2.serv import logger
 from bbc2.lib import support_lib
+from bbc2.lib.support_lib import BYTELEN_BIT256
 from bbclib.libs import bbclib_binary
 from flask import current_app
 
@@ -109,7 +110,7 @@ def file(container):
     dat = bytearray()
     for e in container:
         if e.tag == 'digest':
-            digest = binascii.a2b_hex(e.text)
+            digest = bbclib.convert_idstring_to_bytes(e.text, BYTELEN_BIT256)
             dat.extend(digest)
         elif 'container' in e.attrib and e.attrib['container'] == 'true' \
                 and len(e) > 0:

--- a/bbc2/lib/support_lib.py
+++ b/bbc2/lib/support_lib.py
@@ -15,7 +15,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 import bbclib
-import binascii
 import hashlib
 import os
 
@@ -27,6 +26,16 @@ from bbc2.serv import logger
 
 
 DIR_APP_SUPPORT  = '.bbc2_app'
+
+
+BYTELEN_BIT256 = 256 // 8
+
+MAX_INT8  = 0x7f
+MAX_INT16 = 0x7fff
+MAX_INT32 = 0x7fffffff
+MAX_INT64 = 0x7fffffffffffffff
+
+O_BIT_NONE = 0
 
 
 def get_support_dir(domain_id):
@@ -41,7 +50,8 @@ def get_support_dir(domain_id):
         s_dir (str): The relative path of the application support directory.
 
     """
-    s_domain_id = binascii.b2a_hex(domain_id).decode()
+    s_domain_id = bbclib.convert_id_to_string(domain_id,
+            bytelen=BYTELEN_BIT256)
     s_dir = os.environ.get('BBC2_APP_SUPPORT_DIR', DIR_APP_SUPPORT) + '/' \
             + s_domain_id + '/'
     if not os.path.exists(s_dir):
@@ -61,28 +71,13 @@ def get_working_dir(domain_id):
         s_dir (str): The relative path of the working directory.
 
     """
-    s_domain_id = binascii.b2a_hex(domain_id).decode()
+    s_domain_id = bbclib.convert_id_to_string(domain_id,
+            bytelen=BYTELEN_BIT256)
     s_dir = os.environ.get('BBC2_WORKING_DIR', DEFAULT_WORKING_DIR) + '/' \
             + s_domain_id + '/'
     if not os.path.exists(s_dir):
         os.makedirs(s_dir, mode=0o777, exist_ok=True)
     return s_dir
-
-
-class Constants:
-
-    """Collection of constants to be used in the library or application.
-
-    Common constants are provided. Libraries or applications should derive
-    their own constant classes from this.
-    """
-
-    MAX_INT8  = 0x7f
-    MAX_INT16 = 0x7fff
-    MAX_INT32 = 0x7fffffff
-    MAX_INT64 = 0x7fffffffffffffff
-
-    O_BIT_NONE = 0
 
 
 # end of support_lib.py

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from os import path
 from setuptools import setup
 from setuptools.command.install import install
 
-VERSION = "0.1"
+VERSION = "0.2"
 
 here = path.abspath(path.dirname(__file__))
 


### PR DESCRIPTION
Certify API to use the correct 0-padded 256-bit digest.
- A legacy mode is provided to handle rare cases where this would make it impossible to validate certificates that have been registered in the past.