### PR TITLE
Default brownie network can be specified

### DIFF
--- a/bbc2/serv/ethereum/bbc_ethereum.py
+++ b/bbc2/serv/ethereum/bbc_ethereum.py
@@ -133,7 +133,7 @@ def setup_config(working_dir, file_name, network_name):
 
     if not 'ethereum' in config or not 'network' in config['ethereum']:
         config['ethereum'] = {
-            'network': network_name,
+            'network': network_name if network_name != '' else DEFAULT_NETWORK,
             'private_key': '',
             'contract_address': '',
             'web3_infura_project_id': '',
@@ -141,12 +141,18 @@ def setup_config(working_dir, file_name, network_name):
         }
         isUpdated = True
 
-    elif config['ethereum']['network'] != network_name:
+    elif network_name != '' and config['ethereum']['network'] != network_name:
         config['ethereum']['network'] = network_name
+        isUpdated = True
+
+    elif network_name == '' and config['ethereum']['network'] \
+            != config['ethereum']['default_network']:
+        config['ethereum']['network'] = config['ethereum']['default_network']
         isUpdated = True
 
     if not 'default_network' in config['ethereum']:
         config['ethereum']['default_network'] = DEFAULT_NETWORK
+        isUpdated = True
 
     if isUpdated:
         bbcConfig.update_config()

--- a/bbc2/serv/ethereum/bbc_ethereum.py
+++ b/bbc2/serv/ethereum/bbc_ethereum.py
@@ -29,6 +29,9 @@ from bbc2.serv import bbc_config
 from bbc2.lib.support_lib import BYTELEN_BIT256
 
 
+DEFAULT_NETWORK = 'goerli'
+
+
 def chdir_to_core_path():
     prevdir = chdir_to_this_filepath()
     os.chdir('..')
@@ -94,7 +97,7 @@ def setup_brownie(bbcConfig, infura_project_id):
     Args:
         bbcConfig (BBcConfig): The configuration object.
         infura_project_id (str): INFURA project ID.
-            To be used for setting up 'goerli' and 'mainnet' networks.
+            To be used for setting up testnets and 'mainnet' networks.
 
     """
     config = bbcConfig.get_config()
@@ -134,6 +137,7 @@ def setup_config(working_dir, file_name, network_name):
             'private_key': '',
             'contract_address': '',
             'web3_infura_project_id': '',
+            'default_network': DEFAULT_NETWORK,
         }
         isUpdated = True
 
@@ -141,12 +145,35 @@ def setup_config(working_dir, file_name, network_name):
         config['ethereum']['network'] = network_name
         isUpdated = True
 
+    if not 'default_network' in config['ethereum']:
+        config['ethereum']['default_network'] = DEFAULT_NETWORK
+
     if isUpdated:
         bbcConfig.update_config()
 
     os.chdir(prevdir)
 
     return bbcConfig
+
+
+def setup_default_network(bbcConfig, default_network_name):
+    """Sets brownie default network.
+
+    Args:
+        bbcConfig (BBcConfig): The configuration object.
+        default_network_name (str): The name of the brownie default network.
+
+    """
+
+    prevdir = chdir_to_this_filepath()
+
+    config = bbcConfig.get_config()
+
+    config['ethereum']['network'] = default_network_name
+    config['ethereum']['default_network'] = default_network_name
+
+    bbcConfig.update_config()
+    os.chdir(prevdir)
 
 
 def setup_deploy(bbcConfig):

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from os import path
 from setuptools import setup
 from setuptools.command.install import install
 
-VERSION = "0.2"
+VERSION = "0.2.1"
 
 here = path.abspath(path.dirname(__file__))
 

--- a/utils/bbc_eth_tool.py
+++ b/utils/bbc_eth_tool.py
@@ -135,6 +135,7 @@ if __name__ == '__main__':
 
     if args.network == '':
         args.network = bbcConfig.get_config()['ethereum']['default_network']
+        bbcConfig.get_config()['ethereum']['network'] = args.network
 
     if args.command_type == 'auto':
         print("Setting up brownie.")

--- a/utils/bbc_eth_tool.py
+++ b/utils/bbc_eth_tool.py
@@ -48,8 +48,8 @@ class EthereumSubsystemTool(subsystem_tool_lib.SubsystemTool):
 
     def _add_additional_arguments(self):
         self.argparser.add_argument('-n', '--network', type=str,
-                default='goerli',
-                help='network name (goerli by default)')
+                default='',
+                help='network name')
 
         # account command
         parser = self.subparsers.add_parser('account',
@@ -80,6 +80,14 @@ class EthereumSubsystemTool(subsystem_tool_lib.SubsystemTool):
         # new_account command
         parser = self.subparsers.add_parser('new_account',
                 help='Create a new Ethereum account')
+
+        # set_default_network command
+        parser = self.subparsers.add_parser('set_default_network',
+                help='Set default network with -n option')
+
+        # set_default_network command
+        parser = self.subparsers.add_parser('show_default_network',
+                help='Show default network')
 
         # brownie command
         parser = self.subparsers.add_parser('brownie',
@@ -125,6 +133,9 @@ if __name__ == '__main__':
     bbcConfig = bbc_ethereum.setup_config(args.workingdir, args.config,
             args.network)
 
+    if args.network == '':
+        args.network = bbcConfig.get_config()['ethereum']['default_network']
+
     if args.command_type == 'auto':
         print("Setting up brownie.")
         bbc_ethereum.setup_brownie(bbcConfig, args.project_id)
@@ -138,6 +149,12 @@ if __name__ == '__main__':
 
     elif args.command_type == 'brownie':
         bbc_ethereum.setup_brownie(bbcConfig, args.project_id)
+
+    elif args.command_type == 'show_default_network':
+        print(bbcConfig.get_config()['ethereum']['default_network'])
+
+    elif args.command_type == 'set_default_network':
+        bbc_ethereum.setup_default_network(bbcConfig, args.network)
 
     elif args.command_type == 'test':
         bbc_ethereum.setup_test()

--- a/utils/bbc_eth_tool.py
+++ b/utils/bbc_eth_tool.py
@@ -133,10 +133,6 @@ if __name__ == '__main__':
     bbcConfig = bbc_ethereum.setup_config(args.workingdir, args.config,
             args.network)
 
-    if args.network == '':
-        args.network = bbcConfig.get_config()['ethereum']['default_network']
-        bbcConfig.get_config()['ethereum']['network'] = args.network
-
     if args.command_type == 'auto':
         print("Setting up brownie.")
         bbc_ethereum.setup_brownie(bbcConfig, args.project_id)


### PR DESCRIPTION
- two commands are added to bbc_eth_tool.py that enable users to specify and show the default network to connect.